### PR TITLE
feat: add phonemes to uthmani mapping output to the quran_phonetizer

### DIFF
--- a/src/quran_transcript/phonetics/phonetizer.py
+++ b/src/quran_transcript/phonetics/phonetizer.py
@@ -1,5 +1,6 @@
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
 
 from .operations import OPERATION_ORDER
 from .moshaf_attributes import MoshafAttributes
@@ -7,10 +8,65 @@ from .sifa import process_sifat, SifaOutput
 from .. import alphabet as alph
 
 
+def _distribute_mapping(segment: list[int | None], new_len: int) -> list[int | None]:
+    """Spread original indices over a new segment length."""
+    if new_len <= 0:
+        return []
+    if not segment:
+        return [None] * new_len
+    if len(segment) == 1:
+        return [segment[0]] * new_len
+
+    distributed: list[int | None] = []
+    seg_len = len(segment)
+    for k in range(new_len):
+        idx = int(k * seg_len / new_len)
+        if idx >= seg_len:
+            idx = seg_len - 1
+        distributed.append(segment[idx])
+    return distributed
+
+
+def _align_mapping(
+    before_text: str, after_text: str, before_mapping: list[int | None]
+) -> list[int | None]:
+    """Align mapping list after a text transformation using sequence matching."""
+
+    matcher = SequenceMatcher(a=before_text, b=after_text)
+    new_mapping: list[int | None] = []
+
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            new_mapping.extend(before_mapping[i1:i2])
+        elif tag == "replace":
+            segment = before_mapping[i1:i2]
+            new_mapping.extend(_distribute_mapping(segment, j2 - j1))
+        elif tag == "insert":
+            new_mapping.extend([None] * (j2 - j1))
+        elif tag == "delete":
+            continue
+
+    return new_mapping
+
+
+def _substitute_with_mapping(
+    text: str, mapping: list[int | None], pattern: str, replacement: str
+) -> tuple[str, list[int | None]]:
+    """Apply regex substitution while updating the origin mapping via alignment."""
+
+    new_text = re.sub(pattern, replacement, text)
+    if new_text == text:
+        return text, mapping
+
+    new_mapping = _align_mapping(text, new_text, mapping)
+    return new_text, new_mapping
+
+
 @dataclass
 class QuranPhoneticScriptOutput:
     phonemes: str
     sifat: list[SifaOutput]
+    char_map: list[int | None] = field(default_factory=list)
 
 
 def quran_phonetizer(
@@ -18,13 +74,22 @@ def quran_phonetizer(
 ) -> QuranPhoneticScriptOutput:
     """الرسم الصوتي للقآن الكريم على طبقتين: طبقة الأحرف وطبقة الصفات"""
     text = uhtmani_text
+    mapping: list[int | None] = list(range(len(text)))
 
     # cleaning extra scpace
-    text = re.sub(r"\s+", rf"{alph.uthmani.space}", text)
-    text = re.sub(r"(\s$|^\s)", r"", text)
+    text, mapping = _substitute_with_mapping(
+        text, mapping, r"\s+", rf"{alph.uthmani.space}"
+    )
+    text, mapping = _substitute_with_mapping(text, mapping, r"(\s$|^\s)", r"")
 
     for op in OPERATION_ORDER:
+        prev_text = text
         text = op.apply(text, moshaf)
+        if text != prev_text:
+            # print(f"Applied: {op.arabic_name}")
+            # print(f"  Before: {prev_text}")
+            # print(f"  After : {text}")
+            mapping = _align_mapping(prev_text, text, mapping)
 
     sifat = process_sifat(
         uthmani_script=uhtmani_text,
@@ -33,6 +98,13 @@ def quran_phonetizer(
     )
 
     if remove_spaces:
-        text = re.sub(alph.uthmani.space, r"", text)
+        filtered_chars: list[str] = []
+        filtered_map: list[int | None] = []
+        for ch, idx in zip(text, mapping):
+            if ch != alph.uthmani.space:
+                filtered_chars.append(ch)
+                filtered_map.append(idx)
+        text = "".join(filtered_chars)
+        mapping = filtered_map
 
-    return QuranPhoneticScriptOutput(phonemes=text, sifat=sifat)
+    return QuranPhoneticScriptOutput(phonemes=text, sifat=sifat, char_map=mapping)


### PR DESCRIPTION

## Summary
Introduce and propagate a char-to-phoneme origin mapping through all text normalization and phonetic operations. This enables precise back-references from phonetic output to original Uthmani indices for highlighting, sync, and annotations.

## What changed
- Mapping utilities in `src/quran_transcript/phonetics/phonetizer.py`
  - `_distribute_mapping(segment, new_len)`: spreads original indices across replaced segments.
  - `_align_mapping(before_text, after_text, before_mapping)`: aligns origin indices using `difflib.SequenceMatcher` opcodes.
  - `_substitute_with_mapping(text, mapping, pattern, replacement)`: regex substitution that preserves mapping via alignment.
- `quran_phonetizer`
  - Initialize a `mapping` array with original character indices.
  - Normalize whitespace to `alph.uthmani.space` and trim edges via mapping-aware substitution.
  - After each op in `OPERATION_ORDER`, realign mapping with the transformed text only when the text changes.
  - Respect `remove_spaces` by filtering both phonemes and mapping.
  - Return `QuranPhoneticScriptOutput` with a new `char_map` field populated.
- Typing/docstrings and light refactors for clarity.

## Why
- Required for UI features such as per-phoneme highlighting, cursor sync, and error localization.
- Ensures transformations that insert/delete/replace characters maintain a stable origin link to original Uthmani indices.

## Behavior
- Phoneme string remains functionally unchanged.
- `QuranPhoneticScriptOutput.char_map` exposes per-phoneme origin indices (use `None` when a phoneme has no direct source, e.g., inserted characters).
- Whitespace is canonicalized to `alph.uthmani.space`; `remove_spaces=True` removes those spaces and their indices consistently.

## Implementation notes
- Alignment via `SequenceMatcher.get_opcodes()`:
  - `equal`: carry over the original slice of the mapping.
  - `replace`: distribute the source indices across the new span using `_distribute_mapping`.
  - `insert`: fill with `None` for newly inserted characters.
  - `delete`: dropped characters are omitted from the mapping.
- `_substitute_with_mapping` provides a mapping-safe wrapper around regex substitutions used for normalization.

## Performance
- Alignment is only performed when text actually changes (fast no-op path otherwise).
- `SequenceMatcher` is typically fast for the targeted inputs; worst-case quadratic behavior is acceptable for current use and input sizes.

## Testing suggestions
- Cover opcode cases: `equal`, `replace`, `insert`, `delete` should yield expected `char_map` segments.
- Validate whitespace normalization and `remove_spaces=True` keep `phonemes` and `char_map` in sync.
- Exercise sequences of `OPERATION_ORDER` that expand/contract text; verify indices remain correctly aligned to the original Uthmani string.
- Round-trip sanity: for any mapped index `i`, ensure `output.char_map[j] == i` points back to `uhtmani_text[i]`.

## Backwards compatibility
- No breaking API removals. Downstream consumers can begin using `output.char_map`.
- If external code previously stripped spaces manually, prefer `remove_spaces=True` to keep mapping aligned.

## Affected files
- `src/quran_transcript/phonetics/phonetizer.py`

## Checklist
- [ ] Unit tests for mapping alignment and space handling
- [ ] Documentation for the `char_map` contract and examples
- [ ] Changelog entry
